### PR TITLE
[DRAFT] Minimal QA check on repository

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,32 @@
+name: Node.js CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lint_and_build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+          - 22.x
+          - 20.x
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: cd web
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - master
   push:
     branches:
       - main
+      - master
 
 jobs:
   lint_and_build:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         node-version:
           - 22.x
-          - 20.x
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "git-log--graph",
-	"version": "0.1.21",
+	"version": "0.1.22",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "git-log--graph",
-			"version": "0.1.21",
+			"version": "0.1.22",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -570,7 +570,8 @@
 		}
 	},
 	"scripts": {
-		"postinstall": "cd web && npm install"
+		"postinstall": "cd web && npm install",
+		"lint": "eslint ."
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Just to get started, I looked at CONTRIBUTING.md and saw that the linting is not passing currently, so I went ahead and incorporated the *minimal* steps to lint this project

What is possibly missing from this PR

- Knowing what versions of NodeJS this should support, I set it to 20.x and 22.x
- Making sure it fails if package.json and package-lock.json disagree
- Incorporating the release.sh command, or part of it, into the global `npm run build`
- Marking the web as a module with [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). that would prevent having two different `package-lock.json` and could simplify running everything, `npm install` globally would work and then a task to go along the `launch.json` for development