### PR TITLE
added -x to cherry pick prompt

### DIFF
--- a/web/src/state/default-git-actions.json
+++ b/web/src/state/default-git-actions.json
@@ -166,6 +166,11 @@
 					"value": "--no-commit",
 					"default_active": false,
 					"info": "Usually the command automatically creates a sequence of commits. This flag applies the changes necessary to cherry-pick each named commit to your working tree and the index, without making any commit. In addition, when this option is used, your index does not have to match the HEAD commit. The cherry-pick is done against the beginning state of your index.\n\nThis is useful when cherry-picking more than one commits' effect to your index in a row."
+				},
+        {
+					"value": "-x",
+					"default_active": false,
+					"info": "Record the cherry picked commit.\nThis flag append a line that says \"(cherry picked from commit …​)\" to the original commit message in order to indicate which commit this change was cherry-picked from. This is done only for cherry picks without conflicts.\n\nDo not use this option if you are cherry-picking from your private branch because the information is useless to the recipient. If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 				}
 			]
 		},


### PR DESCRIPTION
When cherry picking, -x is a common option to add which commit was cherry picked. I added that to the prompt. 