### PR TITLE
redesign commit details

### DIFF
--- a/web/src/components/CommitDiff.vue
+++ b/web/src/components/CommitDiff.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="commit-diff">
 		<h3>
-			Changes ({{ file_diffs?.length || 0 }})
+			{{ props.commit2 ? 'Changes between commits' : 'Changes' }} ({{ file_diffs?.length || 0 }})
 		</h3>
 		<aside class="actions center">
 			<button class="row" title="View Changes in Multi Diff" @click="show_multi_diff()">

--- a/web/src/components/RefTip.vue
+++ b/web/src/components/RefTip.vue
@@ -1,9 +1,19 @@
 <template>
-	<div v-context-menu="context_menu_provider" v-drag="drag" v-drop="drop" class="ref-tip" v-bind="bind" @dblclick="dblclick">
-		{{ git_ref.display_name }}
-		<template v-if="branch?.remote_names_group">
-			<span v-for="remote_name of branch.remote_names_group" :key="remote_name" class="remote-name-group-entry"> + {{ remote_name }}</span>
-		</template>
+	<div v-context-menu="context_menu_provider" v-drag="drag" v-drop="drop" class="ref-container" :style="container_style" :class="container_class" @dblclick="dblclick">
+		<span class="ref-icon">
+			<i :class="['codicon', ref_icon_class]" />
+		</span>
+		<span class="ref-separator" />
+		<div class="ref-tip-name">
+			{{ git_ref.display_name }}
+			<template v-if="branch?.remote_names_group">
+				<span v-for="remote_name of branch.remote_names_group" :key="remote_name" class="remote-name-group-entry"> + {{ remote_name }}</span>
+			</template>
+		</div>
+		<span v-if="show_buttons" class="ref-separator" />
+		<span v-if="show_buttons" class="actions-menu">
+			<button class="ellipsis-btn" title="Actions" @click="trigger_ref_context_menu($event)">⋯</button>
+		</span>
 	</div>
 </template>
 <script setup>
@@ -26,6 +36,10 @@ let props = defineProps({
 		type: Object,
 		default: null,
 	},
+	show_buttons: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 let branch = computed(() => {
@@ -34,6 +48,15 @@ let branch = computed(() => {
 	else
 		return null
 })
+
+let ref_icon_class = computed(() => {
+	if (props.git_ref.type === 'tag')
+		return 'codicon-tag'
+	if (props.git_ref.type === 'stash')
+		return 'codicon-archive'
+	return 'codicon-git-branch'
+})
+
 function to_context_menu_entries(/** @type {GitAction[]} */ actions) {
 	return actions.map((action) => ({
 		label: action.title,
@@ -43,24 +66,20 @@ function to_context_menu_entries(/** @type {GitAction[]} */ actions) {
 		},
 	}))
 }
-let	bind = computed(() => {
-	// This also works with remote_names_group-grouped branches, presumably because
-	// the local one is always the first in git log %D ref list, yielding the id
-	let is_head = props.git_ref.id === head_branch.value
-	return {
-		style: {
-			color: props.git_ref.color,
-			border: is_head
-				? `2px solid ${props.git_ref.color}`
-				: undefined,
-		},
-		class: {
-			head: is_head,
-			branch: !! branch.value,
-			inferred: !! branch.value?.inferred,
-		},
-	}
-})
+let is_head = computed(() => props.git_ref.id === head_branch.value)
+
+let container_style = computed(() => ({
+	color: props.git_ref.color,
+	border: is_head.value
+		? `2px solid ${props.git_ref.color}`
+		: '1px solid var(--vscode-editorWidget-border)',
+}))
+
+let container_class = computed(() => ({
+	head: is_head.value,
+	branch: !! branch.value,
+	inferred: !! branch.value?.inferred,
+}))
 let drag = computed(() => {
 	if (branch.value)
 		return props.git_ref.display_name
@@ -95,69 +114,110 @@ function dblclick() {
 	// First action is currently always commit
 	selected_git_action.value = branch_actions(branch.value).value[0] || null
 }
+function trigger_ref_context_menu(/** @type {MouseEvent} */ event) {
+	// Trigger context menu from the ref-tip-name element
+	const targetEl = /** @type {HTMLElement} */ (event.currentTarget || event.target)
+	const ref_tip_element = /** @type {HTMLElement} */ (targetEl?.closest('.ref-container')?.querySelector('.ref-tip-name'))
+	if (! ref_tip_element)
+		return
+
+	const contextEvent = new MouseEvent('contextmenu', {
+		bubbles: true,
+		cancelable: true,
+		view: window,
+		clientX: event.clientX,
+		clientY: event.clientY,
+	})
+	ref_tip_element.dispatchEvent(contextEvent)
+	event.stopPropagation()
+}
 </script>
 <style scoped>
-.ref-tip {
-	background: #1f1f1f;
-	color: #fff;
-	.vscode-light &, .vscode-high-contrast-light & {
-		background: #eee;
-		color: #000;
-	}
-	font-weight: bold;
-	font-style: italic;
-	display: inline-block;
-	padding: 1px 3px;
-	border: 1px solid #505050;
-	border-radius: 7px;
-	white-space: pre;
-	margin: 0 1px;
+.ref-container {
+	display: inline-flex;
+	align-items: center;
+	border-radius: 5px;
+	background: var(--vscode-editor-background);
+	overflow: hidden;
 	max-width: 350px;
+	cursor: default;
+}
+.ref-container.head,
+.ref-container.branch {
+	cursor: move;
+}
+.ref-container:hover {
+	max-width: unset;
+}
+.ref-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0 6px;
+	height: 100%;
+	color: var(--vscode-foreground);
+}
+.ref-icon .codicon {
+	font-size: 12px;
+}
+.ref-separator {
+	width: 1px;
+	height: 16px;
+	background-color: var(--vscode-editorWidget-border);
+	align-self: center;
+}
+.ref-tip-name {
+	background: transparent;
+	font-weight: bold;
+	display: inline-block;
+	padding: 1px 4px;
+	white-space: pre;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
-.ref-tip:hover {
-	max-width: unset;
+.ref-container.head .ref-tip-name:after {
+	content: ' (HEAD)';
+	color: var(--vscode-editor-compositionBorder);
 }
-.ref-tip.head {
-	/* box-shadow: 0px 0px 6px 4px rgba(255,255,255,0.188), 0px 0px 4px 0px rgba(255,255,255,0.188) inset; */
-	&:after {
-		content: ' (HEAD)';
-		color: #fff;
-	}
-	.vscode-light &, .vscode-high-contrast-light & {
-		&:after {
-			color: #000;
-		}
-	}
-}
-.ref-tip.branch {
-	cursor: move;
-}
-.ref-tip.branch.inferred {
-	background: rgba(0,0,0,0.569);
-	.vscode-light &, .vscode-high-contrast-light & {
-		background: rgba(255,255,255,1);
-	}
-	opacity: 0.7;
-	font-weight: normal;
-}
-.ref-tip.branch.inferred:hover {
-	opacity: unset;
-	font-weight: bold;
-	background: #000;
-}
-.ref-tip.branch.dragenter {
-	background: #fff !important;
-	.vscode-light &, .vscode-high-contrast-light & {
-		background: #000 !important;
-	}
+.ref-container.dragenter {
+	background: var(--vscode-list-hoverBackground) !important;
 	color: #f00 !important;
 }
-.remote-name-group-entry {
-	color: #fff;
+.ref-container.inferred {
+	background: rgba(0, 0, 0, 0.3);
 	.vscode-light &, .vscode-high-contrast-light & {
-		color: #000;
-	}
+		background: rgba(255, 255, 255, 1);
+	};
+	opacity: 0.8;
+	font-weight: normal;
+}
+.ref-container.inferred .ref-tip-name {
+	font-weight: normal;
+}
+.ref-container.branch.inferred:hover {
+	opacity: unset;
+}
+.remote-name-group-entry {
+	color: var(--vscode-editor-compositionBorder);
+}
+.actions-menu {
+	display: inline-flex;
+	align-items: stretch;
+}
+.ellipsis-btn {
+	cursor: pointer;
+	border: none;
+	background: transparent;
+	color: inherit;
+	padding: 0 6px;
+	display: inline-flex;
+	align-items: center;
+	line-height: 1;
+	height: 100%;
+	vertical-align: middle;
+	font-size: inherit;
+}
+.ellipsis-btn:hover {
+	background: var(--vscode-list-hoverBackground);
 }
 </style>

--- a/web/src/views/main-view/CommitsDetails.vue
+++ b/web/src/views/main-view/CommitsDetails.vue
@@ -1,28 +1,40 @@
 <template>
 	<div class="commits-details">
-		<h2 class="count">
-			<!-- TODO: styling -->
-			{{ commits.length }} COMMITS SELECTED
-		</h2>
-		<p class="hashes">
-			{{ commits.map(c=>c.hash).join(' ') }}
-		</p>
-		<div class="row gap-5 wrap">
-			<git-action-button v-for="action, i of commits_actions" :key="i" :git_action="action" />
+		<div class="row fill-h">
+			<div class="left flex-1">
+				<h3>
+					{{ commits.length }} commits selected
+					<span class="actions-menu" @click.stop>
+						<button v-context-menu="commits_context_menu_provider" class="ellipsis-btn" @click="trigger_commits_context_menu($event)">⋯</button>
+					</span>
+				</h3>
+				<div class="commit-hashes">
+					<div v-for="commit in commits" :key="commit.hash" class="commit-hash-line">
+						<a class="commit-hash-link" title="Jump to commit" @click="$emit('hash_clicked', commit.hash)">{{ commit.hash }}</a>
+					</div>
+				</div>
+				<template v-if="details_panel_position !== 'bottom'">
+					<template v-if="commits.length===2">
+						<commit-diff :commit1="commits[0]" :commit2="commits[1]" />
+					</template>
+				</template>
+			</div>
+			<div :class="details_panel_position === 'bottom' ? 'flex-1' : ''" class="right">
+				<template v-if="details_panel_position === 'bottom'">
+					<template v-if="commits.length===2">
+						<commit-diff :commit1="commits[0]" :commit2="commits[1]" />
+					</template>
+				</template>
+			</div>
 		</div>
-		<template v-if="commits.length===2">
-			<h3>
-				Comparison of two commits
-			</h3>
-
-			<!-- TODO: [0] should yield unsafe array access type error..?? -->
-			<commit-diff :commit1="commits[0]" :commit2="commits[1]" />
-		</template>
 	</div>
 </template>
 <script setup>
 import { computed } from 'vue'
 import { commits_actions as commits_actions_ } from '../../data/store/actions'
+import { selected_git_action } from '../../data/store/index.js'
+import config from '../../data/store/config.js'
+import vContextMenu from '../../directives/context-menu'
 
 let props = defineProps({
 	commits: {
@@ -32,14 +44,87 @@ let props = defineProps({
 	},
 })
 
+defineEmits(['hash_clicked'])
+
+let details_panel_position = computed(() =>
+	config.get_string('details-panel-position'))
+
 let commits_actions = computed(() => commits_actions_(props.commits.map((c) => c.hash)).value)
+
+function to_context_menu_entries(/** @type {GitAction[]} */ actions) {
+	return actions.map((action) => ({
+		label: action.title,
+		icon: action.icon,
+		action() {
+			selected_git_action.value = action
+		},
+	}))
+}
+
+let commits_context_menu_provider = computed(() => () => to_context_menu_entries(commits_actions.value))
+
+function trigger_commits_context_menu(/** @type {MouseEvent} */ event) {
+	// Simulate right-click to trigger the existing context menu
+	let contextEvent = new MouseEvent('contextmenu', {
+		bubbles: true,
+		cancelable: true,
+		clientX: event.clientX,
+		clientY: event.clientY,
+	})
+	event.target?.dispatchEvent(contextEvent)
+}
 </script>
 <style scoped>
-h2.summary {
-	white-space: pre-line;
-	word-break: break-word;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	margin-top: 0;
+.actions-menu {
+	position: relative;
+	display: inline-flex;
+	align-items: stretch;
+}
+.ellipsis-btn {
+	cursor: pointer;
+	border: 1px solid var(--vscode-editorWidget-border);
+	background: var(--vscode-editor-background);
+	color: inherit;
+	padding: 1px 6px;
+	border-radius: 7px;
+	display: inline-flex;
+	align-items: center;
+	line-height: 1;
+	height: 100%;
+	vertical-align: middle;
+	font-size: inherit;
+	margin-left: 10px;
+}
+.commit-hashes {
+	margin: 10px 0;
+}
+.commit-hash-line {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+	font-family: monospace;
+}
+.commit-hash-link {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	text-decoration: none;
+	font-family: monospace;
+}
+.commit-hash-link:hover {
+	text-decoration: underline;
+}
+.left,
+.right {
+	overflow: auto;
+}
+.row {
+	display: flex;
+}
+.fill-h {
+	height: 100%;
+}
+.flex-1 {
+	flex: 1;
 }
 </style>

--- a/web/src/views/main-view/MainView.vue
+++ b/web/src/views/main-view/MainView.vue
@@ -59,7 +59,7 @@
 					</button>
 				</template>
 				<template v-else-if="selected_commits.length">
-					<commits-details id="selected-commits" :commits="selected_commits" class="flex-1 fill-w padding" />
+					<commits-details id="selected-commits" :commits="selected_commits" class="flex-1 fill-w padding" @hash_clicked="jump_to_commit_hash_or_load($event)" />
 					<button id="close-selected-commits" class="center" title="Close" @click="selected_commits=[]">
 						<i class="codicon codicon-close" />
 					</button>

--- a/web/src/views/main-view/scroller/CommitRow.vue
+++ b/web/src/views/main-view/scroller/CommitRow.vue
@@ -6,7 +6,7 @@
 				<div :style="commit.branch? {color:commit.branch.color} : undefined" class="vis-ascii-circle vis-resize-handle" @mousedown="vis_resize_handle_mousedown">
 					●&nbsp;
 				</div>
-				<commit-ref-tips class="flex-noshrink" :commit="commit" />
+				<commit-ref-tips class="flex-noshrink" :commit="commit" :allow_wrap="false" :show_buttons="false" />
 				<div class="subject">
 					&nbsp;{{ commit.subject }}
 				</div>


### PR DESCRIPTION
Redesigned commit details panel

What is changed:
- ref tips in commit list and in commit details (as it is a single component)
- selected commit info
- show committer info when it is different from commit author

What does not changed:
- design of changes in commit / between commits

### 1 commit selected
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/f7651dc9-480d-4e25-8722-9d9705582136" />

### 2 commits selected
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/bd335af2-f5ad-4305-8dd5-d248d6623d5b" />

### 3+ commits selected
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/f5254758-9257-4992-9798-e1994477428e" />

### 1 commit selected with right sidebar position
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/82d4133a-57f8-41e6-a021-4a618ff7d0f2" />

### 2 commits selected with right sidebar position
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/63d69e2f-b6b7-4c5a-9478-57d825b59d6f" />

### Sidebar with enabled buttons
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/78842519-0dd2-4275-9995-f58eb55ff6a3" />

### Without grouping branches
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/02e7723a-f7bc-49dc-97ed-c89940101e44" />

### Inferred quick branch tips
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/c0b621a9-d103-432a-bd53-466f2409d91e" />

### 1 commit selected with white theme (Light+)
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/dbbdc880-37cb-45cc-b543-2d24ae1bf5bb" />

### Inferred quick branch tips with white theme (Light Modern) and right sidebar position
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/03c601e5-3ba2-4a45-8a2b-5e37d028d7f3" />

### Light High contrast
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/4140c640-e4f9-47f4-8390-fb259a77b2cd" />

### Dark High contrast
<img width="1883" height="1162" alt="image" src="https://github.com/user-attachments/assets/7d9b6809-493a-462b-99ec-850e90c3f711" />
