### PR TITLE
filter out HEAD refs for remotes

### DIFF
--- a/web/src/utils/log-parser.js
+++ b/web/src/utils/log-parser.js
@@ -88,6 +88,8 @@ async function parse(log_data, branch_data, stash_data, separator, curve_radius,
 		let [tracking_remote_name, ref_name] = branch_line.split(separator)
 		if (ref_name?.startsWith('(HEAD detached at '))
 			continue
+		if (ref_name?.match(/^refs\/remotes\/[^/]+\/HEAD$/))
+			continue
 		new_branch(ref_name || '???', { tracking_remote_name })
 	}
 	// Not actually a branch but since it's included in the log refs and is neither stash nor tag
@@ -131,6 +133,7 @@ async function parse(log_data, branch_data, stash_data, separator, curve_radius,
 			// map to ["master", "origin/master", "tag: xyz"]
 			.map((r) => r.split(' -> ')[1] || r)
 			.filter((r) => r !== 'refs/stash')
+			.filter((r) => ! r.match(/^refs\/remotes\/[^/]+\/HEAD$/))
 			.filter(is_truthy)
 			.map((id) => {
 				if (id.startsWith('tag: refs/tags/')) {


### PR DESCRIPTION
Hide HEAD refs for remotes, as they does not shows in most of git clients.

### Before

<img width="1374" height="75" alt="image" src="https://github.com/user-attachments/assets/6aff1a96-99b2-47a2-b7ee-5d71b29ba064" />

<img width="1411" height="239" alt="image" src="https://github.com/user-attachments/assets/1e171d71-10e2-4119-ba87-f2a552d8cdaf" />

### After

<img width="1378" height="64" alt="image" src="https://github.com/user-attachments/assets/46f7e2ce-19c4-449e-97ad-ef2bae01aace" />

<img width="1382" height="234" alt="image" src="https://github.com/user-attachments/assets/4c58d7d1-f030-474d-8d23-6f039a5ee2b5" />
