### PR TITLE
show avatars in log (gravatar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,11 @@
 					"type": "boolean",
 					"default": false
 				},
+				"git-log--graph.show-avatars": {
+					"description": "Show avatars for each commit in commit log (using Gravatar).",
+					"type": "boolean",
+					"default": true
+				},
 				"git-log--graph.disable-preliminary-loading": {
 					"description": "Normally, once at extension start, the first few commits are queried and shown thanks to a small request optimized for speed while the rest keeps loading in the background. This is especially helpful with large repos and if the -n option is set to a high value such as 15000, the default number of commits loaded. But since this request does not respect your configured log arguments, you may see slightly different results for a few moments. If it bothers you, you can disable this first small request by setting this option to true.",
 					"type": "boolean",

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,5 +1,6 @@
 let vscode = require('vscode')
 let path = require('path')
+let crypto = require('crypto')
 let RelativeTime = require('@yaireo/relative-time')
 let relative_time = new RelativeTime()
 require('./globals')
@@ -166,6 +167,8 @@ module.exports.activate = intercept_errors(function(/** @type {vscode.ExtensionC
 						})
 						case 'clipboard-write-text': return h(() =>
 							vscode.env.clipboard.writeText(data))
+						case 'md5-hash': return h(() =>
+							crypto.createHash('md5').update(data.toLowerCase().trim()).digest('hex'))
 					}
 			}
 		}))
@@ -189,7 +192,7 @@ module.exports.activate = intercept_errors(function(/** @type {vscode.ExtensionC
 				(is_production ? '' : dev_server_url) + '; ' +
 			'connect-src ' +
 				(is_production ? '' : '*') + '; ' +
-			`img-src ${view.cspSource} data: ` +
+			`img-src ${view.cspSource} data: https://www.gravatar.com ` +
 				(is_production ? '' : dev_server_url) + '; '
 		let base_url = is_production
 			? view.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'web-dist')) + '/'

--- a/web/src/bridge.js
+++ b/web/src/bridge.js
@@ -65,3 +65,6 @@ export let show_error_message = (/** @type {string} */ msg) =>
 
 export let add_push_listener = (/** @type {string} */ id, /** @type {(r: BridgeMessage) => void} */ handler) =>
 	push_handlers[id] = handler
+
+export let md5_hash = (/** @type {string} */ email) =>
+	exchange_message('md5-hash', email)

--- a/web/src/utils/gravatar.js
+++ b/web/src/utils/gravatar.js
@@ -1,0 +1,162 @@
+import { md5_hash } from '../bridge'
+
+/**
+ * Avatar cache with localStorage persistence
+ */
+class AvatarCache {
+	constructor() {
+		this.cache_key = 'gitlg_avatar_cache'
+		this.expiry_days = 7
+	}
+
+	/**
+	 * Get cached avatar
+	 * @param {string} email_hash
+	 * @returns {string|null} base64 image data or null if not cached/expired
+	 */
+	get(email_hash) {
+		try {
+			let cache = JSON.parse(localStorage.getItem(this.cache_key) || '{}')
+			let entry = cache[email_hash]
+
+			if (! entry)
+				return null
+
+			let now = Date.now()
+			let expiry = entry.timestamp + (this.expiry_days * 24 * 60 * 60 * 1000)
+
+			if (now > expiry) {
+				delete cache[email_hash]
+				localStorage.setItem(this.cache_key, JSON.stringify(cache))
+				return null
+			}
+
+			return entry.data
+		} catch (e) {
+			console.warn('Failed to read avatar cache:', e)
+			return null
+		}
+	}
+
+	/**
+	 * Store avatar in cache
+	 * @param {string} email_hash
+	 * @param {string} base64_data
+	 */
+	set(email_hash, base64_data) {
+		try {
+			let cache = JSON.parse(localStorage.getItem(this.cache_key) || '{}')
+			cache[email_hash] = {
+				data: base64_data,
+				timestamp: Date.now(),
+			}
+			localStorage.setItem(this.cache_key, JSON.stringify(cache))
+		} catch (e) {
+			console.warn('Failed to write avatar cache:', e)
+		}
+	}
+
+	/**
+	 * Clear expired entries from cache
+	 */
+	cleanup() {
+		try {
+			let cache = JSON.parse(localStorage.getItem(this.cache_key) || '{}')
+			let now = Date.now()
+			let expiry_time = this.expiry_days * 24 * 60 * 60 * 1000
+			let cleaned = false
+
+			for (let hash in cache)
+				if (now > cache[hash].timestamp + expiry_time) {
+					delete cache[hash]
+					cleaned = true
+				}
+
+			if (cleaned)
+				localStorage.setItem(this.cache_key, JSON.stringify(cache))
+		} catch (e) {
+			console.warn('Failed to cleanup avatar cache:', e)
+		}
+	}
+}
+
+let avatar_cache = new AvatarCache()
+
+/**
+ * Convert image URL to base64 data URL
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function image_to_base64(url) {
+	return new Promise((resolve, reject) => {
+		let img = new Image()
+		img.crossOrigin = 'anonymous'
+
+		img.onload = () => {
+			let canvas = document.createElement('canvas')
+			let ctx = canvas.getContext('2d')
+
+			if (! ctx) {
+				reject(new Error('Could not get canvas context'))
+				return
+			}
+
+			canvas.width = img.width
+			canvas.height = img.height
+
+			ctx.drawImage(img, 0, 0)
+
+			try {
+				let data_url = canvas.toDataURL('image/png')
+				resolve(data_url)
+			} catch (e) {
+				reject(e)
+			}
+		}
+
+		img.onerror = () => reject(new Error('Failed to load image'))
+		img.src = url
+	})
+}
+
+/**
+ * Get Gravatar URL for email
+ * @param {string} email
+ * @param {number} size
+ * @returns {Promise<string>}
+ */
+async function get_gravatar_url(email, size = 32) {
+	let hash = await md5_hash(email)
+	return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=identicon&r=pg`
+}
+
+/**
+ * Get avatar for email with caching
+ * @param {string} email
+ * @returns {Promise<string|null>} base64 data URL or null
+ */
+export async function get_avatar(email) {
+	if (! email)
+		return null
+
+	let hash = await md5_hash(email)
+
+	let cached = avatar_cache.get(hash)
+	if (cached)
+		return cached
+
+	try {
+		let gravatar_url = await get_gravatar_url(email)
+		let base64_data = await image_to_base64(gravatar_url)
+
+		avatar_cache.set(hash, base64_data)
+
+		return base64_data
+	} catch (e) {
+		console.warn('Failed to fetch avatar for:', email, e)
+		return null
+	}
+}
+
+// Cleanup expired cache entries on load
+avatar_cache.cleanup()

--- a/web/src/views/main-view/scroller/CommitRow.vue
+++ b/web/src/views/main-view/scroller/CommitRow.vue
@@ -12,7 +12,15 @@
 				</div>
 			</div>
 			<div :title="commit.author_name+' <'+commit.author_email+'>'" class="author align-center">
-				{{ commit.author_name }}
+				<div v-if="show_avatars && commit.author_email" class="avatar-placeholder">
+					<img v-if="author_avatar" :src="author_avatar" class="avatar" alt="">
+					<div v-else class="avatar-initial">
+						{{ commit.author_name?.[0]?.toUpperCase() || '?' }}
+					</div>
+				</div>
+				<div class="author-name">
+					{{ commit.author_name }}
+				</div>
 			</div>
 			<div class="stats flex-noshrink row align-center justify-flex-end gap-5">
 				<template v-if="commit.stats?.files_changed">
@@ -38,9 +46,10 @@
 	</div>
 </template>
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import { vis_width } from '../../../data/store'
 import config from '../../../data/store/config'
+import { get_avatar } from '../../../utils/gravatar'
 
 let props = defineProps({
 	commit: {
@@ -75,6 +84,39 @@ function vis_resize_handle_mousedown(/** @type {MouseEvent} */ mousedown_event) 
 }
 let calculated_height = computed(() =>
 	props.height || config.get_number('row-height'))
+
+let show_avatars = computed(() =>
+	config.get_boolean_or_undefined('show-avatars') !== false)
+
+let author_avatar = ref(/** @type {string|null} */ (null))
+
+async function load_avatar() {
+	// Reset first to show initial state during loading
+	author_avatar.value = null
+
+	if (! show_avatars.value || ! props.commit.author_email)
+		return
+
+	try {
+		let avatar_data = await get_avatar(props.commit.author_email)
+		author_avatar.value = avatar_data
+	} catch (e) {
+		console.warn('Failed to load avatar:', e)
+		author_avatar.value = null
+	}
+}
+
+onMounted(() => {
+	load_avatar()
+})
+
+watch(() => props.commit.author_email, () => {
+	load_avatar()
+})
+
+watch(show_avatars, () => {
+	load_avatar()
+})
 </script>
 <style scoped>
 .commit-row {
@@ -90,8 +132,8 @@ let calculated_height = computed(() =>
 	font-family: monospace;
 }
 .info > .subject-wrapper {
+	flex: 3 1 0;
 	min-width: 150px;
-	display: inline-flex;
 }
 .info > .subject-wrapper:hover {
 	overflow: visible;
@@ -117,9 +159,47 @@ let calculated_height = computed(() =>
 }
 .info > .datetime {
 	font-size: 12px;
+	text-align: left;
+	justify-content: flex-start;
+	display: flex;
+	width: 150px;
+	min-width: 150px;
 }
 .info > .author {
-	max-width: 150px;
+	flex: 1 1 0;
+	text-align: left;
+	justify-content: flex-start;
+	align-items: center;
+}
+.avatar-placeholder {
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	position: relative;
+	overflow: hidden;
+	margin-right: 4px;
+}
+.avatar {
+	width: 100%;
+	height: 100%;
+	border-radius: 50%;
+}
+.avatar-initial {
+	width: 100%;
+	height: 100%;
+	background: var(--vscode-list-activeSelectionBackground);
+	color: var(--vscode-list-activeSelectionForeground);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 9px;
+	font-weight: bold;
+	border-radius: 50%;
+}
+.author-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .info .stats {
 	width: 91px;


### PR DESCRIPTION
Show avatar for author in commit log.

- fetch avatars from Gravatar with hashed author email
- can be disabled via settings
- fallback to author initial letter (during load or load errors, ex.: no internet access)

### Before

<img width="1651" height="841" alt="image" src="https://github.com/user-attachments/assets/2389d302-b559-4e1a-b0d3-bc270fe25a22" />

### Enabled avatars

<img width="1656" height="846" alt="image" src="https://github.com/user-attachments/assets/21eb28b2-ff9e-4c59-8bfa-19783c76fb3d" />

### Disabled avatars

<img width="1656" height="846" alt="image" src="https://github.com/user-attachments/assets/dde418e3-868a-498a-a87b-84f0ad0f6544" />

### Fallback to initial letter

<img width="1656" height="846" alt="image" src="https://github.com/user-attachments/assets/272a6814-8ac1-45dc-90e7-b8a840dcc76e" />

### Fallback to initial letter with white theme

<img width="1656" height="846" alt="image" src="https://github.com/user-attachments/assets/add51c40-998b-40df-b386-567cbc9f26b9" />
