### PR TITLE
fix: correctly handle renamed files in the commit view (list + diffs)

### DIFF
--- a/web/src/components/CommitDiff.vue
+++ b/web/src/components/CommitDiff.vue
@@ -127,6 +127,25 @@ let props = defineProps({
 /** @type {Vue.Ref<FileDiff[] | null>} */
 let file_diffs = ref(null)
 
+/**
+ * Expand git's compact rename spec into its old and new paths.
+ * Handles `dir/{old => new}/file`, `{old => new}/file`, `dir/{ => new}/file`,
+ * `dir/{old => }/file` and the plain `old => new` form.
+ * @type {(spec: string) => { old_path: string, new_path: string }}
+ */
+function split_rename(spec) {
+	let brace = spec.match(/^(.*)\{(.*) => (.*)\}(.*)$/)
+	if (brace) {
+		let pre = brace[1] || ''
+		let post = brace[4] || ''
+		let join = (/** @type {string} */ mid) => (pre + mid + post).replace(/\/{2,}/g, '/')
+		return { old_path: join(brace[2] || ''), new_path: join(brace[3] || '') }
+	}
+	let split = spec.split(' => ')
+	let from = split[0] || ''
+	return { old_path: from, new_path: split[1] || from }
+}
+
 function git_numstat_summary_to_changes_array(/** @type {string} */ out) {
 	return Object.values(out.split('\n').filter(Boolean)
 		.reduce((/** @type {Record<string, FileDiff>} */ all, line) => {
@@ -140,12 +159,15 @@ function git_numstat_summary_to_changes_array(/** @type {string} */ out) {
 						else if (split[1] === 'create')
 							all[path].is_creation = true
 				} else if (split[1] === 'rename') {
-					// TODO: this is very hacky, --summary output is obviously not meant to be parsed
+					// --summary output is obviously not meant to be parsed
 					// rename Theme/Chicago95/{index.theme => index1.theme} (100%)
-					let match = line.match(/^ rename ((.+) => .+) \(\d+%\)$/)
-					let change = all[(match?.[2] || '').replaceAll('{', '')]
-					if (change)
-						change.rename_path = match?.[1]
+					let match = line.match(/^ rename (.+) \(\d+%\)$/)
+					let spec = match?.[1] || ''
+					if (spec) {
+						let change = all[split_rename(spec).old_path]
+						if (change)
+							change.rename_path = spec
+					}
 				}
 			} else {
 				let split = line.split('\t')
@@ -154,7 +176,7 @@ function git_numstat_summary_to_changes_array(/** @type {string} */ out) {
 				let rename_description = undefined
 				if (path.includes(' => ')) {
 					rename_description = path
-					path = path.split(' => ')[0]?.replaceAll('{', '') || ''
+					path = split_rename(path).old_path
 				}
 				all[path] = {
 					path,

--- a/web/src/components/CommitDiff.vue
+++ b/web/src/components/CommitDiff.vue
@@ -38,20 +38,20 @@
 		</template-file-change-define>
 		<template-file-actions-define v-slot="{ file }">
 			<div class="file-actions row align-center">
-				<button class="row show-file" title="Show file history" @click.stop="show_file(file.path)">
+				<button class="row show-file" title="Show file history" @click.stop="show_file(file)">
 					<i class="codicon codicon-history" />
 				</button>
-				<button class="row view-rev" title="View File at this Revision" @click.stop="view_rev(file.path)">
+				<button class="row view-rev" title="View File at this Revision" @click.stop="view_rev(file)">
 					<i class="codicon codicon-git-commit" />
 				</button>
-				<button class="row open-file" title="Open file" @click.stop="open_file(file.path)">
+				<button class="row open-file" title="Open file" @click.stop="open_file(file)">
 					<i class="codicon codicon-go-to-file" />
 				</button>
 			</div>
 		</template-file-actions-define>
 
 		<ul v-if="files_list" class="list">
-			<li v-for="file of files_list" :key="file.path" class="list-row flex-1 row align-center gap-10" role="button" @click="show_diff(file.path)">
+			<li v-for="file of files_list" :key="file.path" class="list-row flex-1 row align-center gap-10" role="button" @click="show_diff(file)">
 				<div class="flex-1 fill-h row align-center gap-10">
 					<img :src="file.icon_path" aria-hidden="true">
 					<div :title="file.filename" class="filename">
@@ -74,7 +74,7 @@
 				<div class="body">
 					<template-tree-node-reuse v-for="child of node.children" :key="child.path" :node="child" />
 					<template v-for="file of node.files" :key="file.path">
-						<button class="fill-w row align-center gap-10" @click="show_diff(file.path)">
+						<button class="fill-w row align-center gap-10" @click="show_diff(file)">
 							<img :src="file.icon_path" aria-hidden="true">
 							<div :title="file.filename" class="filename flex-1">
 								{{ file.filename }}
@@ -102,6 +102,7 @@ import state from '../data/state.js'
 /**
  * @typedef {{
  *	path: string
+ *	new_path: string
  *	insertions: number
  *	deletions: number
  *  is_deletion?: boolean
@@ -172,14 +173,18 @@ function git_numstat_summary_to_changes_array(/** @type {string} */ out) {
 			} else {
 				let split = line.split('\t')
 				let path = split[2] || ''
+				let new_path = path
 				/** @type {string | undefined} */
 				let rename_description = undefined
 				if (path.includes(' => ')) {
 					rename_description = path
-					path = split_rename(path).old_path
+					let renamed = split_rename(path)
+					path = renamed.old_path
+					new_path = renamed.new_path
 				}
 				all[path] = {
 					path,
+					new_path,
 					insertions: Number(split[0]),
 					deletions: Number(split[1]),
 					rename_path: rename_description,
@@ -216,12 +221,15 @@ watchEffect(async () => {
 	file_diffs.value = git_numstat_summary_to_changes_array(await git(get_files_command))
 })
 
-function show_diff(/** @type {string} */ filepath) {
+// For a renamed file the old name (file.path) exists only in hash1 and the new
+// name (file.new_path) only in hash2, so each side must use its own path — using
+// one path for both revisions yields an empty pane on the side where it's absent.
+function show_diff(/** @type {FileDiff} */ file) {
 	return exchange_message('open-diff', {
-		title: `${filepath} ${hash1.value} - ${hash2(filepath)}`,
+		title: `${file.new_path} ${hash1.value} - ${hash2(file.path)}`,
 		uris: [
-			`${hash1.value}:${filepath}`,
-			`${hash2(filepath)}:${filepath}`,
+			`${hash1.value}:${file.path}`,
+			`${hash2(file.path)}:${file.new_path}`,
 		],
 	})
 }
@@ -230,24 +238,24 @@ function show_multi_diff() {
 		title: `${hash1.value} - ${hash2()}`,
 		uris: (file_diffs.value || []).map(file => [
 			`${hash1.value}:${file.path}`,
-			`${hash2(file.path)}:${file.path}`,
+			`${hash2(file.path)}:${file.new_path}`,
 		]),
 	})
 }
-function view_rev(/** @type {string} */ filepath) {
+function view_rev(/** @type {FileDiff} */ file) {
 	return exchange_message('view-rev', {
-		uri: `${hash2(filepath)}:${filepath}`,
+		uri: `${hash2(file.path)}:${file.new_path}`,
 	})
 }
 
-function open_file(/** @type {string} */ filepath) {
-	return exchange_message('open-file', { uri: filepath })
+function open_file(/** @type {FileDiff} */ file) {
+	return exchange_message('open-file', { uri: file.new_path })
 }
 
-function show_file(/** @type {string} */ filepath) {
+function show_file(/** @type {FileDiff} */ file) {
 	return trigger_main_refresh({
 		custom_log_args: ({ base_log_args }) =>
-			`${base_log_args} --follow -- "${filepath}"`,
+			`${base_log_args} --follow -- "${file.new_path}"`,
 		fetch_stash_refs: false,
 	})
 }


### PR DESCRIPTION
Fixes #187. Fixes #131.

Supersedes #188 — that PR fixed only the file-list parsing (#187). While
testing it I found that once renamed files finally appear in the list, opening
their diff still breaks (#131), because the two bugs share the same root cause:
renames aren't tracked through to the paths used per revision. This PR fixes
both, so I'll close #188 in favour of it.

This is two commits; they can be reviewed independently.

---

## Commit 1 — parse git's compact `{old => new}` rename notation (#187)

When a commit renames a directory, git reports the moved files with its
**compact** rename notation, e.g. `src/{old => new}/file.txt`. The file-list
parser (`git_numstat_summary_to_changes_array` in
`web/src/components/CommitDiff.vue`, fed by `git show --numstat --summary`) only
understood the **full-path** form `old => new`.

For a numstat row like `src/{old => new}/file.txt` it did:

```js
path = path.split(' => ')[0]?.replaceAll('{', '') || ''
// "src/{old => new}/file.txt"
//   .split(' => ')[0]   -> "src/{old"
//   .replaceAll('{','') -> "src/old"   <-- truncated at the brace; "/file.txt" is lost
```

So **every** file renamed under the same directory collapsed onto the *same*
key (`src/old`) and the entries overwrote each other in the accumulator — only
the last survived. The `--summary` rename branch had the same assumption, so it
couldn't reconcile either. Result: files silently missing from the commit's
file list, and a basename that also appeared as a plain add/delete pair could
show up duplicated.

**Fix:** a small `split_rename()` helper expands git's compact form
`prefix/{old => new}/suffix` (and the degenerate `{old => new}`,
`dir/{ => new}/f`, `dir/{old => }/f`, and plain `old => new`) into the real
old/new paths, and the entries are keyed on the real **old** path in both the
numstat branch and the `--summary` rename branch.

## Commit 2 — use old/new paths for renamed files in commit diffs (#131)

Once #187 makes renamed files appear in the list, clicking one opened an empty
diff (and "View File at this Revision" opened an empty editor). A renamed file's
**old** name exists only in the parent commit and its **new** name only in the
child, but the handlers used a single path for both revisions:

```js
uris: [
  `${hash1.value}:${filepath}`,   // parent : path
  `${hash2(filepath)}:${filepath}`, // child : SAME path  <- absent here for a rename
]
```

So the child side resolved a path that doesn't exist in that commit and rendered
empty.

**Fix:** track `new_path` on each `FileDiff`, and use the **old** path at
`hash1` and the **new** path at `hash2` in `show_diff` / `show_multi_diff` /
`view_rev`, and the **new** path for `open_file` / `show_file`. Non-renamed
files are unaffected because `new_path === path` for them.

---

## Verification

Built and type-checked locally against a fresh checkout:

- `npm run build` (vite + esbuild) — **passes**.
- `vue-tsc --noEmit` — **no new errors** from either change (the one remaining
  `CommitDiff.vue` diagnostic is pre-existing and present on the unmodified
  tree, just line-shifted).
- Parser check on a directory rename (`src/old/` → `src/new/`): **before** only
  1 of 2 renamed files appeared (both collapsed onto one key); **after** both
  appear with correct old/new paths. The loss scales with the directory — an
  N-file rename previously collapsed all N brace entries onto a single key.
- Diff-URI check on a rename: **before** the child side reused the old path and
  the pane was empty; **after** it resolves parent:`old` ↔ child:`new` and both
  panes populate. Modified/created/deleted files produce identical URIs to
  before.

> Note: `npm run lint` currently crashes in a fresh checkout on
> `src/global.d.ts` (a `@typescript-eslint`/TS version issue, unrelated to this
> change), so I couldn't run the lint gate — the type-check and build above
> cover this file.

## Reproduce the original bugs

```bash
git init demo && cd demo
mkdir -p src/old
printf 'a\n'    > src/old/keep.txt
printf 'a\nb\n' > src/old/edit.txt
git add -A && git commit -m init
git mv src/old src/new                 # rename the directory (both files move)
git commit -am "rename dir"
```

Open the `rename dir` commit:

- **Before #187:** at least one renamed file is missing from the file list;
  with more files in the directory, several go missing and a basename can appear
  duplicated.
- **Before #131:** the renamed files that *do* show open an empty diff and an
  empty "View File at this Revision".
- **After this PR:** all renamed files are listed, and their diffs and file
  views open correctly.
